### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "10up/mu-migration",
     "description": "A set of WP-CLI commands to support the migration of single WordPress instances to multisite",
+    "type": "wp-cli-package",
     "homepage": "https://github.com/10up/MU-Migration",
     "support": {
         "issues": "https://github.com/10up/MU-Migration/issues"


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567