### PR TITLE
Closing #9 - export current theme(s) only

### DIFF
--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -421,7 +421,11 @@ class ExportCommand extends MUMigrationBase {
 		}
 
 		if ( $include_themes ) {
-			$files_to_zip[] = get_theme_root();
+			$file_to_zip[] = get_template_directory();
+			if( is_child_theme() ) {
+				$files_to_zip[] = get_stylesheet_directory();
+			}
+			
 		}
 
 		if ( $include_uploads ) {

--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -421,11 +421,10 @@ class ExportCommand extends MUMigrationBase {
 		}
 
 		if ( $include_themes ) {
-			$file_to_zip[] = get_template_directory();
+			$files_to_zip[] = get_template_directory();
 			if( is_child_theme() ) {
 				$files_to_zip[] = get_stylesheet_directory();
 			}
-			
 		}
 
 		if ( $include_uploads ) {


### PR DESCRIPTION
updated export all to only export the currently activated theme and if it is a child theme also export the theme-template/parent theme.

This way not every theme installed in a multisite will be zipped.

closes #9
