### PR TITLE
Wrapping the sql export into a single transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ you can pass it to the `import all` command.
 $ wp mu-migration import all site.zip --new_url=multisite.dev/site
 ```
 
+The import command also supports a `--mysql-single-transaction` parameter that will wrap the sql export into a single transaction to commit
+all changes from the import at one time preventing the write from overwhelming the database server, especially in clustered mysql enviroments.
+
 After the migration you can also manage users password (reset passwords and/or force users to reset their passwords).
 ```
 $ wp mu-migration update_passwords [<newpassword>] [--blog_id=<blog_id>] [--reset] [--send_email] [--include=<users_id>]  [--exclude=<users_id>]

--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -119,6 +119,7 @@ class ExportCommand extends MUMigrationBase {
 			);
 
 			if ( 0 === $export ) {
+				Helpers\addTransaction($filename);
 				$this->success( __( 'The export is now complete', 'mu-migration' ), $verbose );
 			} else {
 				\WP_CLI::error( __( 'Something went wrong while trying to export the database', 'mu-migration' ) );

--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -119,7 +119,6 @@ class ExportCommand extends MUMigrationBase {
 			);
 
 			if ( 0 === $export ) {
-				Helpers\addTransaction($filename);
 				$this->success( __( 'The export is now complete', 'mu-migration' ), $verbose );
 			} else {
 				\WP_CLI::error( __( 'Something went wrong while trying to export the database', 'mu-migration' ) );

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -377,7 +377,7 @@ class ImportCommand extends MUMigrationBase {
 	 *
 	 *      wp mu-migration import all site.zip
 	 *
-	 * @synopsis <zipfile> [--blog_id=<blog_id>] [--new_url=<new_url>] [--verbose]
+	 * @synopsis <zipfile> [--blog_id=<blog_id>] [--new_url=<new_url>] [--verbose] [--mysql-single-transaction]
 	 */
 	public function all( $args = array(), $assoc_args = array() ) {
 		$this->process_args(
@@ -385,7 +385,8 @@ class ImportCommand extends MUMigrationBase {
 			$args,
 			array(
 				'blog_id' 	=> '',
-				'new_url'	=> ''
+				'new_url'	=> '',
+				'mysql-single-transaction' => false
 			),
 			$assoc_args
 		);
@@ -461,6 +462,14 @@ class ImportCommand extends MUMigrationBase {
 		}
 
 		WP_CLI::log( __( 'Importing tables...', 'mu-migration' ) );
+
+		/*
+		 * If the flag --mysql-single-transaction is passed, then the SQL is wrapped with
+		 * START TRANSACTION and COMMIT to insert in one single transaction
+		 */
+		if ( $assoc_args['mysql-single-transaction'] ) {
+			Helpers\addTransaction( $sql[0] );
+		}
 
 		$this->tables( array( $sql[0] ), $tables_assoc_args, $verbose );
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -241,3 +241,25 @@ function stop_the_insanity() {
 	}
 
 }
+
+/**
+ * Add START TRANSACTION and COMMIT to the sql export
+ * shamlessly stolen from http://stackoverflow.com/questions/1760525/need-to-write-at-beginning-of-file-with-php
+ *
+ * @param $orig_filename  sql dump file name
+ *
+ */
+
+function addTransaction($orig_filename) {
+  $context = stream_context_create();
+  $orig_file = fopen($orig_filename, 'r', 1, $context);
+
+  $temp_filename = tempnam(sys_get_temp_dir(), 'php_prepend_');
+  file_put_contents($temp_filename, 'START TRANSACTION;\n');
+  file_put_contents($temp_filename, $orig_file, FILE_APPEND);
+  file_put_contents($temp_filename, 'COMMIT;', FILE_APPEND);
+
+  fclose($orig_file);
+  unlink($orig_filename);
+  rename($temp_filename, $orig_filename);
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -255,7 +255,7 @@ function addTransaction($orig_filename) {
   $orig_file = fopen($orig_filename, 'r', 1, $context);
 
   $temp_filename = tempnam(sys_get_temp_dir(), 'php_prepend_');
-  file_put_contents($temp_filename, 'START TRANSACTION;\n');
+  file_put_contents($temp_filename, 'START TRANSACTION;' . PHP_EOL );
   file_put_contents($temp_filename, $orig_file, FILE_APPEND);
   file_put_contents($temp_filename, 'COMMIT;', FILE_APPEND);
 

--- a/mu-migration.php
+++ b/mu-migration.php
@@ -3,7 +3,7 @@
  * Plugin Name: MU Migration
  * Plugin URI: http://10up.com
  * Description: A set of WP-CLI commands to support the migration of single WordPress instances over to multisite
- * Version: 0.2.4
+ * Version: 0.2.5
  * Author: Nícholas André, 10up
  * Author URI: http://10up.com
  * Text Domain: mu-migration
@@ -17,7 +17,7 @@ if ( defined( 'TENUP_MU_MIGRATION_VERSION' ) || ! defined( 'WP_CLI' ) ) {
 	return;
 }
 
-define( 'TENUP_MU_MIGRATION_VERSION', '0.2.4' );
+define( 'TENUP_MU_MIGRATION_VERSION', '0.2.5' );
 define( 'TENUP_MU_MIGRATION_COMMANDS_PATH', 'includes/commands/' );
 
 // we only need to require autoload if running as a plugin


### PR DESCRIPTION
adding code to insert "START TRANSACTION; ... COMMIT;" to the beginning and end of the sql dump in the export file.

This will wrap the entire sql import into a single transaction to commit all the changes from the import at one time
and prevent the write from overwhelming the database server, especially in clustered mysql envrionments

could possibly make this a command line option, rather than doing it for everyone by default