### PR TITLE
Ensure static zip file structure

### DIFF
--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -441,19 +441,21 @@ class ExportCommand extends MUMigrationBase {
 		);
 
 		if ( $include_plugins ) {
-			$files_to_zip[] = WP_PLUGIN_DIR;
+			$files_to_zip['wp-content/plugins'] = WP_PLUGIN_DIR;
 		}
 
 		if ( $include_themes ) {
-			$files_to_zip[] = get_template_directory();
-			if( is_child_theme() ) {
-				$files_to_zip[] = get_stylesheet_directory();
+			$theme_dir = get_template_directory();
+			$files_to_zip[ 'wp-content/themes/' . basename( $theme_dir ) ] = $theme_dir;
+			if ( is_child_theme() ) {
+				$child_theme_dir = get_stylesheet_directory();
+				$files_to_zip[ 'wp-content/themes/' . basename( $child_theme_dir ) ] = $child_theme_dir;
 			}
 		}
 
 		if ( $include_uploads ) {
 			$upload_dir = wp_upload_dir();
-			$files_to_zip[] = $upload_dir['basedir'];
+			$files_to_zip['wp-content/uploads'] = $upload_dir['basedir'];
 		}
 
 		try{


### PR DESCRIPTION
Make sure the zip file structure is the same, no matter where the wp-cli command was called from.

The folders in the zip file will now always have the correct structure:
```
- wp-content
  - plugins
  - themes
  - uploads
```

@nicholasio I was thinking of omitting the `wp-content` and having the subfolders directly on the root level, but opted to leave it as is.
This ensures that all existing exports will still work seamlessly, without the need of any code fixes to accommodate that.