### PR TITLE
Ability to import into a single site installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MU-Migration
 
-This WP-CLI plugin makes the process of moving sites from single WordPress sites to a Multisite instance much easier.
+This WP-CLI plugin makes the process of moving sites from single WordPress sites to a Multisite instance (or vice-versa) much easier.
 It exports everything into a zip package which can be used to automatically import it within the desired Multisite installation.
 
 <a href="http://10up.com/contact/"><img src="https://10updotcom-wpengine.s3.amazonaws.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
@@ -15,7 +15,7 @@ Clone this repo onto `plugins/` folder, run `composer install` to fetch dependen
 You need to install this on both the site you're moving and the target Multisite installation.
 
 ### Why do I need this? ###
-Moving single WordPress sites to a Multisite environment can be challenging, specially if you're moving more than one site to
+Moving single WordPress sites to a Multisite environment (or the opposite) can be challenging, specially if you're moving more than one site to
 Multisite. You'd need to replace tables prefix, update post_author and wc_customer_user (if WooCommerce is installed) with the new
 users ID (Multisite has a shared users table, so if you're moving more than one site you can't guarantee that users will have the same IDs) and more.
 
@@ -33,11 +33,19 @@ The above command will export users, tables, plugins folder, themes folder and t
 move to the Multisite server in order to be imported with the `import all` command. The optional flags `--plugins --themes --uploads`,
 add the plugins folder, themes folder and uploads folder to the zip file respectively.
 
+You can also export subsites from another multisite instance, to do so pass the `--blog_id` parameter. E.g:
+
+```
+$ wp mu-migration export all subsite.zip --blog_id=2
+```
+
 The following command can be used to import a site from a zip package.
 ```
 $ wp mu-migration import all site.zip
 ```
-It will create a new site within your Multisite network based on the site you have just exported, the `import all` command will take care
+If importing into Multisite, it will create a new site within your Multisite network based on the site you have just exported, if importing into a single install, it will override your single install with the exported subsite. 
+
+The `import all` command will take care
 of everything that needs to be done when moving a site to Multisite (replacing tables prefix, updating post_author IDs and etc).
 
 If you need to set up a new url for the site you're importing (if importing into staging or local environments for example),
@@ -50,16 +58,14 @@ $ wp mu-migration import all site.zip --new_url=multisite.dev/site
 The import command also supports a `--mysql-single-transaction` parameter that will wrap the sql export into a single transaction to commit
 all changes from the import at one time preventing the write from overwhelming the database server, especially in clustered mysql enviroments.
 
-You can also export subsites from another multisite instance, to do so pass the `--blog_id` parameter. E.g:
+You can also pass `--blog_id` to the `import all` command, in that case the import will override an existing subsite.
 
 ```
-$ wp mu-migration export all subsite.zip --blog_id=2
+$ wp mu-migration import all site.zip --new_url=multisite.dev/site --blog_id=3
 ```
-
-The `import` commando also supports `--blog_id`, in that case the import will override an existing subsite.
 
 In some edge cases it's possible that MU-Migration won't be able to recognize all custom tables while doing the export of a subsite in multisite
-so if you need to make sure to move non-default tables, you can use `--tables` or `--non-default-tables` param. E.g
+so if you need to move non-default tables, you can use `--tables` or `--non-default-tables` param. E.g
 
 ```
 $ wp mu-migration export all subsite.zip --blog_id=1 --non-default-tables=wp_my_custom_table,wp_my_custom_table_2

--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -398,7 +398,7 @@ class ExportCommand extends MUMigrationBase {
 		$switched = false;
 
 		if ( isset( $assoc_args['blog_id'] ) ) {
-			switch_to_blog( (int) $assoc_args['blog_id'] );
+			Helpers\maybe_switch_to_blog( (int) $assoc_args['blog_id'] );
 			$switched = true;
 		}
 
@@ -462,7 +462,7 @@ class ExportCommand extends MUMigrationBase {
 		$meta_data_file = 'mu-migration-' . $rand . sanitize_title( $site_data['name'] ) . '.json';
 
 		\WP_CLI::log( __( 'Exporting site meta data...', 'mu-migration' ) );
-		file_put_contents( $meta_data_file, json_encode( $site_data ) );
+		file_put_contents( $meta_data_file, wp_json_encode( $site_data ) );
 
 		\WP_CLI::log( __( 'Exporting users...', 'mu-migration' ) );
 		$this->users( array( $users_file ), $users_assoc_args, $verbose );
@@ -529,7 +529,7 @@ class ExportCommand extends MUMigrationBase {
 		}
 
 		if ( $switched ) {
-			restore_current_blog();
+			Helpers\maybe_restore_current_blog();
 		}
 	}
 

--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -415,7 +415,12 @@ class ExportCommand extends MUMigrationBase {
 			'site_language' => sanitize_text_field( get_bloginfo( 'language' ) ),
 			'db_prefix'     => $wpdb->prefix,
 			'plugins'       => get_plugins(),
+			'blog_id'       => 1
 		);
+
+		if ( isset( $assoc_args['blog_id'] ) ) {
+			$site_data['blog_id'] = get_current_blog_id();
+		}
 
 		$this->process_args(
 			array(

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -81,9 +81,7 @@ class ImportCommand extends MUMigrationBase {
 
 			$line = 0;
 
-			if ( $is_multisite ) {
-				switch_to_blog( $this->assoc_args['blog_id'] );
-			}
+			Helpers\maybe_switch_to_blog( $this->assoc_args['blog_id'] );
 
 			wp_suspend_cache_addition( true );
 			while ( false !== ( $data = fgetcsv( $input_file_handler, 0, $delimiter ) ) ) {
@@ -206,9 +204,7 @@ class ImportCommand extends MUMigrationBase {
 
 			wp_suspend_cache_addition( false );
 
-			if ( $is_multisite ) {
-				restore_current_blog();
-			}
+			Helpers\maybe_restore_current_blog();
 
 			if ( ! empty( $ids_maps ) ) {
 				// Saving the ids_maps to a file.
@@ -350,9 +346,7 @@ class ImportCommand extends MUMigrationBase {
 				}
 			}
 
-			if ( $is_multisite ) {
-				switch_to_blog( (int) $this->assoc_args['blog_id'] );
-			}
+			Helpers\maybe_switch_to_blog( (int) $this->assoc_args['blog_id'] );
 
 			// Update the new tables to work properly with multisite.
 			$new_wp_roles_option_key = $wpdb->prefix . 'user_roles';
@@ -375,9 +369,7 @@ class ImportCommand extends MUMigrationBase {
 				)
 			);
 
-			if ( $is_multisite ) {
-				restore_current_blog();
-			}
+			Helpers\maybe_restore_current_blog();
 		}
 	}
 
@@ -539,9 +531,9 @@ class ImportCommand extends MUMigrationBase {
 			/*
 			 * Flush the rewrite rules for the newly created site, just in case.
 			 */
-			switch_to_blog( $blog_id );
+			Helpers\maybe_switch_to_blog( $blog_id );
 			flush_rewrite_rules();
-			restore_current_blog();
+			Helpers\maybe_restore_current_blog();
 		}, 9999 );
 
 		WP_CLI::log( __( 'Removing temporary files....', 'mu-migration' ) );

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -327,13 +327,21 @@ class ImportCommand extends MUMigrationBase {
 
 				$this->log( __( 'Running Search and Replace for uploads paths', 'mu-migration' ), $verbose );
 
-				/*
-				 * If the $blog_id equals 1 the upload path remains the same.
-				 */
+				$from = false;
+				$to   = false;
+
 				if ( $this->assoc_args['blog_id'] > 1 ) {
+					$from = 'wp-content/uploads';
+					$to = 'wp-content/uploads/sites/' . $this->assoc_args['blog_id'];
+				} else if ( $this->assoc_args['original_blog_id'] > 1 && ! $is_multisite ) {
+					$from = 'wp-content/uploads/sites/' . $this->assoc_args['original_blog_id'];
+					$to = 'wp-content/uploads';
+				}
+
+				if ( $from && $to ) {
 					$search_replace = \WP_CLI::launch_self(
 						'search-replace',
-						array( 'wp-content/uploads', 'wp-content/uploads/sites/' . $this->assoc_args['blog_id'] ),
+						array( $from , $to ),
 						array(),
 						false,
 						false,
@@ -463,9 +471,10 @@ class ImportCommand extends MUMigrationBase {
 		}
 
 		$tables_assoc_args = array(
-			'blog_id'    => $blog_id,
-			'old_prefix' => $site_meta_data->db_prefix,
-			'new_prefix' => Helpers\get_db_prefix( $blog_id ),
+			'blog_id'          => $blog_id,
+			'original_blog_id' => $site_meta_data->blog_id,
+			'old_prefix'       => $site_meta_data->db_prefix,
+			'new_prefix'       => Helpers\get_db_prefix( $blog_id ),
 		);
 
 		/*

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -589,9 +589,9 @@ class ImportCommand extends MUMigrationBase {
 	private function move_uploads( $uploads_dir, $blog_id ) {
 		if ( file_exists( $uploads_dir ) ) {
 			\WP_CLI::log( __( 'Moving Uploads...', 'mu-migration' ) );
-			switch_to_blog( $blog_id );
+			Helpers\maybe_switch_to_blog( $blog_id );
 			$dest_uploads_dir = wp_upload_dir();
-			restore_current_blog();
+			Helpers\maybe_restore_current_blog();
 
 			Helpers\move_folder( $uploads_dir, $dest_uploads_dir['basedir'] );
 		}

--- a/includes/commands/class-mu-migration-posts.php
+++ b/includes/commands/class-mu-migration-posts.php
@@ -46,15 +46,15 @@ class PostsCommand extends MUMigrationBase {
 
 		$filename = $this->args[0];
 
+		$is_multisite = is_multisite();
+
 		if ( empty( $filename ) || ! file_exists( $filename ) ) {
 			WP_CLI::error( __( 'Invalid input file', 'mu-migration' ) );
 		}
 
-		if ( empty( $this->assoc_args['blog_id'] ) ) {
-			WP_CLI::error( __( 'Please, provide a blog id', 'mu-migration' ) );
+		if ( $is_multisite ) {
+			switch_to_blog( (int) $this->assoc_args['blog_id'] );
 		}
-
-		switch_to_blog( (int) $this->assoc_args['blog_id'] );
 
 		$is_woocommerce = Helpers\is_woocommerce_active();
 
@@ -142,7 +142,9 @@ class PostsCommand extends MUMigrationBase {
 			), $verbose );
 		}
 
-		restore_current_blog();
+		if ( $is_multisite ) {
+			restore_current_blog();
+		}
 	}
 }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -267,3 +267,23 @@ function addTransaction( $orig_filename ) {
 	unlink( $orig_filename );
 	rename( $temp_filename, $orig_filename );
 }
+
+/**
+ * Switches to another blog if on Multisite
+ *
+ * @param $blog_id
+ */
+function maybe_switch_to_blog( $blog_id ) {
+	if ( is_multisite() ) {
+		switch_to_blog( $blog_id );
+	}
+}
+
+/**
+ * Restore the current blog if on multisite
+ */
+function maybe_restore_current_blog() {
+	if ( is_multisite() ) {
+		restore_current_blog();
+	}
+}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -167,7 +167,7 @@ function light_add_user_to_blog( $blog_id, $user_id, $role ) {
 
 	if ( ! $user ) {
 		restore_current_blog();
-		return new WP_Error( 'user_does_not_exist', __( 'The requested user does not exist.' ) );
+		return new \WP_Error( 'user_does_not_exist', __( 'The requested user does not exist.' ) );
 	}
 
 	if ( ! get_user_meta( $user_id, 'primary_blog', true ) ) {

--- a/mu-migration.php
+++ b/mu-migration.php
@@ -3,7 +3,7 @@
  * Plugin Name: MU Migration
  * Plugin URI: http://10up.com
  * Description: A set of WP-CLI commands to support the migration of single WordPress instances over to multisite
- * Version: 0.2.8
+ * Version: 0.3.0
  * Author: Nícholas André, 10up
  * Author URI: http://10up.com
  * Text Domain: mu-migration
@@ -17,7 +17,7 @@ if ( defined( 'TENUP_MU_MIGRATION_VERSION' ) || ! defined( 'WP_CLI' ) ) {
 	return;
 }
 
-define( 'TENUP_MU_MIGRATION_VERSION', '0.2.8' );
+define( 'TENUP_MU_MIGRATION_VERSION', '0.3.0' );
 define( 'TENUP_MU_MIGRATION_COMMANDS_PATH', 'includes/commands/' );
 
 // we only need to require autoload if running as a plugin


### PR DESCRIPTION
This PR makes it possible to import subsites previously exported with the tool into a single WordPress installation. #25 

This is a work in progress, needs more testing:

- [x] Test migrating a subsite with ID > 1 into a single install and check for paths
- [X] Test migrating a subsite with ID = 1 into a single install and check for paths
- [x] Regression testing.