### PR TITLE
fix php notice

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -650,7 +650,7 @@ class ImportCommand extends MUMigrationBase {
 		$parsed_url = parse_url( esc_url( $meta_data->url ) );
 		$site_id    = 1;
 
-		$parsed_url['path'] = isset($parsed_url['path'])? $parsed_url['path'] : '/';
+		$parsed_url['path'] = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '/';
 
 		if ( domain_exists( $parsed_url['host'], $parsed_url['path'], $site_id ) ) {
 			return false;

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -650,6 +650,8 @@ class ImportCommand extends MUMigrationBase {
 		$parsed_url = parse_url( esc_url( $meta_data->url ) );
 		$site_id    = 1;
 
+		$parsed_url['path'] = $parsed_url['path']?? '/';
+
 		if ( domain_exists( $parsed_url['host'], $parsed_url['path'], $site_id ) ) {
 			return false;
 		}

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -650,7 +650,7 @@ class ImportCommand extends MUMigrationBase {
 		$parsed_url = parse_url( esc_url( $meta_data->url ) );
 		$site_id    = 1;
 
-		$parsed_url['path'] = $parsed_url['path']?? '/';
+		$parsed_url['path'] = isset($parsed_url['path'])? $parsed_url['path'] : '/';
 
 		if ( domain_exists( $parsed_url['host'], $parsed_url['path'], $site_id ) ) {
 			return false;


### PR DESCRIPTION
$parsed_url['path'] is readed even if it's not instantiated.
The PR adds the variable instantiation if needed.