### PR TITLE
Pass global params

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -307,7 +307,6 @@ class ImportCommand extends MUMigrationBase {
 
 				$global_config = \WP_CLI::get_config();
 				$global_config['url'] = $new_url;
-####QUI VIENE AGGIUNTA LA RIGA MALEFICA! MA NON SEMBRA ESSERE NEMMENO LA CLASSE Roles
 				$search_replace = \WP_CLI::launch_self(
 					'search-replace',
 					array(


### PR DESCRIPTION
I've tried to use the import feature with the --skip-plugins global param. I've noted that this arguments (as every global argument) it's not passed to the internal calls to wp-cli.
This PR passes to WP_CLI::launch_self() the correct global parameters.