### PR TITLE
Use base_prefix rather than prefix when fetching db prefix for subsite

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -146,7 +146,7 @@ function get_db_prefix( $blog_id ) {
 	global $wpdb;
 
 	if ( $blog_id > 1 ) {
-		$new_db_prefix = $wpdb->prefix . $blog_id . '_';
+		$new_db_prefix = $wpdb->base_prefix . $blog_id . '_';
 	} else {
 		$new_db_prefix = $wpdb->prefix;
 	}


### PR DESCRIPTION
Very small change -- use `$wpdb->base_prefix` instead of `$wpdb->prefix` when fetching database prefix for a subsite.

I found this when I was importing to a site where `$wpdb->prefix` returned `wp_1_` instead of `wp_` (on the main site). This may not be a common thing, but it still seems like slightly better practice to use `base_prefix`, since that's really what we're looking to concatenate with `$blog_id . _`