### PR TITLE
Allows command line argument to define postmeta fields that contain user ids (Fixes #48)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ notifications:
     on_success: never
     on_failure: change
 
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ notifications:
     on_success: never
     on_failure: change
 
-# branches:
-#   only:
-#     - master
+branches:
+  only:
+    - master
 
 cache:
   directories:

--- a/features/05-posts.feature
+++ b/features/05-posts.feature
@@ -18,7 +18,7 @@ Feature: Test MU-Migration posts command.
         And I run `wp db prefix --url=example.com/site-2`
         And save STDOUT as {SUB_DB_PREFIX}
         And I run `wp mu-migration import tables tables.sql --blog_id=2 --old_prefix={DB_PREFIX} --new_prefix={SUB_DB_PREFIX} --old_url=http://singlesite.com --new_url=http://example.com/site-2`
-        And I run `wp mu-migration posts update_author users-mapping.json --blog_id=2`
+        And I run `wp mu-migration posts update_author users-mapping.json --blog_id=2 --uid_fields='_a_userid_field'`
         Then STDOUT should not contain:
         """
         records failed to update its post_author:
@@ -30,7 +30,7 @@ Feature: Test MU-Migration posts command.
         ann
         """
 
-        When I run `wp user get $(wp post meta get 5 _a_userid_field) --field=login`
+        When I run `wp user get $(wp post meta get 5 --url=example.com/site-2 _a_userid_field) --field=login`
         Then STDOUT should be:
         """
         ann

--- a/features/05-posts.feature
+++ b/features/05-posts.feature
@@ -7,7 +7,7 @@ Feature: Test MU-Migration posts command.
 
         When I run `wp user create ann ann@example.com  --path=singlesite`
         And I run `wp post generate --count=10 --post_type=post --post_author=ann --path=singlesite`
-        And I insert arbitrary UID postmeta data for user "ann" in site "singlesite"
+        And I insert arbitrary UID postmeta data for user "ann@example.com" in site "singlesite"
         And I run `wp mu-migration export users users.csv --path=singlesite`
         And I run `wp mu-migration export tables tables.sql --path=singlesite`
         And I run `wp mu-migration import users users.csv --blog_id=2 --map_file=users-mapping.json`

--- a/features/05-posts.feature
+++ b/features/05-posts.feature
@@ -7,6 +7,7 @@ Feature: Test MU-Migration posts command.
 
         When I run `wp user create ann ann@example.com  --path=singlesite`
         And I run `wp post generate --count=10 --post_type=post --post_author=ann --path=singlesite`
+        And I insert arbitrary UID postmeta data for user "ann" in site "singlesite"
         And I run `wp mu-migration export users users.csv --path=singlesite`
         And I run `wp mu-migration export tables tables.sql --path=singlesite`
         And I run `wp mu-migration import users users.csv --blog_id=2 --map_file=users-mapping.json`
@@ -24,6 +25,12 @@ Feature: Test MU-Migration posts command.
         """
 
         When I run `wp user get $(wp post get 5 --url=example.com/site-2 --field=post_author) --field=login`
+        Then STDOUT should be:
+        """
+        ann
+        """
+
+        When I run `wp user get $(wp post meta get 5 _a_userid_field) --field=login`
         Then STDOUT should be:
         """
         ann

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -238,9 +238,9 @@ $steps->Given( '/^a PHP built-in web server$/',
 
 $steps->Give( '/^I insert arbitrary UID postmeta data for user "([a-zA-Z0-9.@]+)" in site "(.*)"$/',
 	function ( $world, $user, $site ) {
-		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
+		$postids = invoke_proc( $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) ), 'run' );
         $postids = explode( "\n", $postids );
-        $userid = $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) )->run_check();
+        $userid = invoke_proc( $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) ), 'run' );
         foreach ( $postids as $pid ) {
             $pid = trim( $pid );
             $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, $userid, $site ) )->run_check();

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -238,12 +238,12 @@ $steps->Given( '/^a PHP built-in web server$/',
 
 $steps->Give( '/^I insert arbitrary UID postmeta data for user "([a-zA-Z0-9.@]+)" in site "(.*)"$/',
 	function ( $world, $user, $site ) {
-		$postids = invoke_proc( $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) ), 'run' );
-        $postids = explode( "\n", $postids );
-        $userid = invoke_proc( $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) ), 'run' );
+		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
+        $postids = explode( "\n", $postids->stdout );
+        $userid = $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) )->run_check();
         foreach ( $postids as $pid ) {
             $pid = trim( $pid );
-            $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, $userid, $site ) )->run_check();
+            $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, $userid->stdout, $site ) )->run_check();
         }
 	}
 );

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -241,9 +241,10 @@ $steps->Give( '/^I insert arbitrary UID postmeta data for user "([a-zA-Z0-9.@]+)
 		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
         $postids = explode( "\n", $postids->stdout );
         $userid = $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) )->run_check();
-        foreach ( $postids as $pid ) {
-            $pid = trim( $pid );
-            $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, $userid->stdout, $site ) )->run_check();
-        }
+        print_r($postids);
+        $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', "5", trim( $userid->stdout ), $site ) )->run_check();
+        // foreach ( $postids as $pid ) {
+        //     $pid = trim( $pid );
+        // }
 	}
 );

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -101,7 +101,7 @@ $steps->Given( '/^a WP multisite (subdirectory|subdomain)?\s?install$/',
 	}
 );
 
-$steps->Given( '/^I create multiple sites with dummy content$/', 
+$steps->Given( '/^I create multiple sites with dummy content$/',
 	function( $world ) {
 		$world->proc( 'wp user generate --count=10' )->run_check();
 		$world->proc( 'wp post generate --count=50 --post_type=post' )->run_check();
@@ -116,13 +116,13 @@ $steps->Given( '/^I create multiple sites with dummy content$/',
 				'title'	=> 'Site 3',
 			)
 		);
-		
+
 		foreach( $sites as $site ) {
 			$world->proc( sprintf( 'wp site create --slug=%s --title="%s"', $site['slug'], $site['title'] ) )->run_check();
 			$world->proc( sprintf( 'wp user generate --format=ids --count=10 --url=example.com/%s', $site['slug'] ) )->run_check();
 			$world->proc( sprintf( 'wp post generate --count=50 --post_type=post --url=example.com/%s', $site['slug'] ) )->run_check();
 		}
-	} 
+	}
 );
 
 $steps->Given( '/^these installed and active plugins:$/',
@@ -233,5 +233,17 @@ $steps->Given( '/^a dependency on current wp-cli$/',
 $steps->Given( '/^a PHP built-in web server$/',
 	function ( $world ) {
 		$world->start_php_server();
+	}
+);
+
+$steps->Give( '/^I insert arbitrary UID postmeta data for user "(\w+)" in site "(.*)"$/',
+	function ( $world, $user, $site ) {
+		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
+        $postids = explode( "\n", $postids );
+        $userid = $world->proc( sprintf( 'wp user get %s --field=ID', $user ) )->run_check();
+        foreach ( $postids as $pid ) {
+            $pid = trim( $pid );
+            $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, $userid, $site ) )->run_check();
+        }
 	}
 );

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -236,7 +236,7 @@ $steps->Given( '/^a PHP built-in web server$/',
 	}
 );
 
-$steps->Give( '/^I insert arbitrary UID postmeta data for user "(\w+)" in site "(.*)"$/',
+$steps->Give( '/^I insert arbitrary UID postmeta data for user "([a-zA-Z0-9.@]+)" in site "(.*)"$/',
 	function ( $world, $user, $site ) {
 		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
         $postids = explode( "\n", $postids );

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -240,7 +240,7 @@ $steps->Give( '/^I insert arbitrary UID postmeta data for user "([a-zA-Z0-9.@]+)
 	function ( $world, $user, $site ) {
 		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
         $postids = explode( "\n", $postids );
-        $userid = $world->proc( sprintf( 'wp user get %s --field=ID', $user ) )->run_check();
+        $userid = $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) )->run_check();
         foreach ( $postids as $pid ) {
             $pid = trim( $pid );
             $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, $userid, $site ) )->run_check();

--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -241,10 +241,11 @@ $steps->Give( '/^I insert arbitrary UID postmeta data for user "([a-zA-Z0-9.@]+)
 		$postids = $world->proc( sprintf( 'wp post list --field=ID --path=%s', $site ) )->run_check();
         $postids = explode( "\n", $postids->stdout );
         $userid = $world->proc( sprintf( 'wp user get %s --field=ID --path=%s', $user, $site ) )->run_check();
-        print_r($postids);
-        $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', "5", trim( $userid->stdout ), $site ) )->run_check();
-        // foreach ( $postids as $pid ) {
-        //     $pid = trim( $pid );
-        // }
+        foreach ( $postids as $pid ) {
+            $pid = trim( $pid );
+            if ( !empty( $pid ) ) {
+                $world->proc( sprintf( 'wp post meta add %s _a_userid_field %s --path=%s', $pid, trim( $userid->stdout ), $site ) )->run_check();                
+            }
+        }
 	}
 );

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -401,7 +401,7 @@ class ImportCommand extends MUMigrationBase {
 				'blog_id'                  => '',
 				'new_url'                  => '',
 				'mysql-single-transaction' => false,
-                'uid_fields' => '',
+				'uid_fields' => '',
 			),
 			$assoc_args
 		);

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -386,9 +386,9 @@ class ImportCommand extends MUMigrationBase {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *      wp mu-migration import all site.zip
+	 *      wp mu-migration import all site.zip --uid_fields=_content_audit_owner
 	 *
-	 * @synopsis <zipfile> [--blog_id=<blog_id>] [--new_url=<new_url>] [--verbose] [--mysql-single-transaction]
+	 * @synopsis <zipfile> [--blog_id=<blog_id>] [--new_url=<new_url>] [--verbose] [--mysql-single-transaction] [--uid_fields=<uid_fields>]
 	 *
 	 * @param array $args
 	 * @param array $assoc_args
@@ -401,6 +401,7 @@ class ImportCommand extends MUMigrationBase {
 				'blog_id'                  => '',
 				'new_url'                  => '',
 				'mysql-single-transaction' => false,
+                'uid_fields' => '',
 			),
 			$assoc_args
 		);
@@ -526,6 +527,7 @@ class ImportCommand extends MUMigrationBase {
 				array( $map_file ),
 				array(
 					'blog_id' => $blog_id,
+					'uid_fields' => $assoc_args['uid_fields'],
 				),
 				$verbose
 			);
@@ -568,8 +570,8 @@ class ImportCommand extends MUMigrationBase {
 			foreach ( $plugins as $plugin_name => $plugin ) {
 				$plugin_folder = dirname( $plugin_name );
 				$fullPluginPath = $plugins_dir . '/' . $plugin_folder;
-				
-				if ( $check_plugins &&  ! in_array( $plugin_name, $blog_plugins, true ) && 
+
+				if ( $check_plugins &&  ! in_array( $plugin_name, $blog_plugins, true ) &&
 					! in_array( $plugin_name, $network_plugins, true ) ) {
 					continue;
 				}

--- a/includes/commands/class-mu-migration-posts.php
+++ b/includes/commands/class-mu-migration-posts.php
@@ -109,29 +109,28 @@ class PostsCommand extends MUMigrationBase {
 					$author_not_found[] = absint( $result->ID );
 				}
 
+				// Parse uid_fields
+				$uid_fields = explode( ',', $this->assoc_args['uid_fields'] );
 				// Automatically add Woocommerce user id field
 				if ( $is_woocommerce ) {
-					$this->assoc_args['uid_fields'] .= ',_customer_user';
+					$uid_fields[] = '_customer_user';
 				}
-				// Explode and trim uid fields.
-				$uid_fields = array_filter( array_map( function($e) { return trim($e); }, explode( ',', $this->assoc_args['uid_fields'] )));
 				// Iterate over fields and update them.
-				if (! empty( $uid_fields ) ) {
-					foreach ( $uid_fields as $f ) {
-						$old_user = get_post_meta( (int) $result->ID, $f, true );
+				foreach ( array_filter( $uid_fields ) as $f ) {
+					$f = trim( $f );
+					$old_user = get_post_meta( (int) $result->ID, $f, true );
 
-						if ( isset( $ids_map->{$old_user} ) && $old_user != $ids_map->{$old_user} ) {
-							$new_user = $ids_map->{$old_user};
+					if ( isset( $ids_map->{$old_user} ) && $old_user != $ids_map->{$old_user} ) {
+						$new_user = $ids_map->{$old_user};
 
-							update_post_meta( (int) $result->ID, $f, $new_user );
+						update_post_meta( (int) $result->ID, $f, $new_user );
 
-							$this->log( sprintf(
-								__( 'Updated %s for "%s" (ID #%d)', 'mu-migration' ),
-								$f,
-								$result->post_title,
-								absint( $result->ID )
-							), $verbose );
-						}
+						$this->log( sprintf(
+							__( 'Updated %s for "%s" (ID #%d)', 'mu-migration' ),
+							$f,
+							$result->post_title,
+							absint( $result->ID )
+						), $verbose );
 					}
 				}
 			}

--- a/includes/commands/class-mu-migration-posts.php
+++ b/includes/commands/class-mu-migration-posts.php
@@ -40,6 +40,7 @@ class PostsCommand extends MUMigrationBase {
 			$args,
 			array(
 				'blog_id' => '',
+				'user_id_fields' => '',
 			),
 			$assoc_args
 		);
@@ -106,6 +107,29 @@ class PostsCommand extends MUMigrationBase {
 					), $verbose );
 
 					$author_not_found[] = absint( $result->ID );
+				}
+
+				if ( \array_key_exists('user_id_fields', $this->assoc_args)) {
+					// Explode and trim uid fields.
+					$uidfields = array_filter( array_map( function($e) { return trim($e); }, explode( ',', 'user_id_fields' )));
+					if (! empty( $uidfields ) ) {
+						foreach ( $uidfields as $f ) {
+							$old_user = get_post_meta( (int) $result->ID, $f, true );
+
+							if ( isset( $ids_map->{$old_user} ) && $old_user != $ids_map->{$old_user} ) {
+								$new_user = $ids_map->{$old_user};
+
+								update_post_meta( (int) $result->ID, $f, $new_user );
+
+								$this->log( sprintf(
+									__( 'Updated %s for "%s" (ID #%d)', 'mu-migration' ),
+									$f,
+									$result->post_title,
+									absint( $result->ID )
+								), $verbose );
+							}
+						}
+					}
 				}
 
 				if ( $is_woocommerce ) {

--- a/includes/commands/class-mu-migration-posts.php
+++ b/includes/commands/class-mu-migration-posts.php
@@ -22,9 +22,9 @@ class PostsCommand extends MUMigrationBase {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *   wp mu-migration posts update_author map_users.json --blog_id=2
+	 *   wp mu-migration posts update_author map_users.json --blog_id=2 --uid_fields=_content_audit_owner
 	 *
-	 * @synopsis <inputfile> --blog_id=<blog_id>
+	 * @synopsis <inputfile> --blog_id=<blog_id> [--uid_fields=<uid_fields>]
 	 *
 	 * @param array $args
 	 * @param array $assoc_args
@@ -40,7 +40,7 @@ class PostsCommand extends MUMigrationBase {
 			$args,
 			array(
 				'blog_id' => '',
-				'user_id_fields' => '',
+				'uid_fields' => '',
 			),
 			$assoc_args
 		);
@@ -109,11 +109,12 @@ class PostsCommand extends MUMigrationBase {
 					$author_not_found[] = absint( $result->ID );
 				}
 
-				if ( \array_key_exists('user_id_fields', $this->assoc_args)) {
+				if ( array_key_exists('uid_fields', $this->assoc_args)) {
 					// Explode and trim uid fields.
-					$uidfields = array_filter( array_map( function($e) { return trim($e); }, explode( ',', 'user_id_fields' )));
-					if (! empty( $uidfields ) ) {
-						foreach ( $uidfields as $f ) {
+					$uid_fields = array_filter( array_map( function($e) { return trim($e); }, explode( ',', $this->assoc_args['uid_fields'] )));
+                    // Iterate over fields and update them.
+                    if (! empty( $uid_fields ) ) {
+						foreach ( $uid_fields as $f ) {
 							$old_user = get_post_meta( (int) $result->ID, $f, true );
 
 							if ( isset( $ids_map->{$old_user} ) && $old_user != $ids_map->{$old_user} ) {

--- a/includes/commands/class-mu-migration-posts.php
+++ b/includes/commands/class-mu-migration-posts.php
@@ -39,7 +39,7 @@ class PostsCommand extends MUMigrationBase {
 			),
 			$args,
 			array(
-				'blog_id' => '',
+				'blog_id'    => '',
 				'uid_fields' => '',
 			),
 			$assoc_args
@@ -109,43 +109,29 @@ class PostsCommand extends MUMigrationBase {
 					$author_not_found[] = absint( $result->ID );
 				}
 
-				if ( array_key_exists('uid_fields', $this->assoc_args)) {
-					// Explode and trim uid fields.
-					$uid_fields = array_filter( array_map( function($e) { return trim($e); }, explode( ',', $this->assoc_args['uid_fields'] )));
-                    // Iterate over fields and update them.
-                    if (! empty( $uid_fields ) ) {
-						foreach ( $uid_fields as $f ) {
-							$old_user = get_post_meta( (int) $result->ID, $f, true );
-
-							if ( isset( $ids_map->{$old_user} ) && $old_user != $ids_map->{$old_user} ) {
-								$new_user = $ids_map->{$old_user};
-
-								update_post_meta( (int) $result->ID, $f, $new_user );
-
-								$this->log( sprintf(
-									__( 'Updated %s for "%s" (ID #%d)', 'mu-migration' ),
-									$f,
-									$result->post_title,
-									absint( $result->ID )
-								), $verbose );
-							}
-						}
-					}
-				}
-
+				// Automatically add Woocommerce user id field
 				if ( $is_woocommerce ) {
-					$old_customer_user = get_post_meta( (int) $result->ID, '_customer_user', true );
+					$this->assoc_args['uid_fields'] .= ',_customer_user';
+				}
+				// Explode and trim uid fields.
+				$uid_fields = array_filter( array_map( function($e) { return trim($e); }, explode( ',', $this->assoc_args['uid_fields'] )));
+				// Iterate over fields and update them.
+				if (! empty( $uid_fields ) ) {
+					foreach ( $uid_fields as $f ) {
+						$old_user = get_post_meta( (int) $result->ID, $f, true );
 
-					if ( isset( $ids_map->{$old_customer_user} ) && $old_customer_user != $ids_map->{$old_customer_user} ) {
-						$new_customer_user = $ids_map->{$old_customer_user};
+						if ( isset( $ids_map->{$old_user} ) && $old_user != $ids_map->{$old_user} ) {
+							$new_user = $ids_map->{$old_user};
 
-						update_post_meta( (int) $result->ID, '_customer_user', $new_customer_user );
+							update_post_meta( (int) $result->ID, $f, $new_user );
 
-						$this->log( sprintf(
-							__( 'Updated customer_user for "%s" (ID #%d)', 'mu-migration' ),
-							$result->post_title,
-							absint( $result->ID )
-						), $verbose );
+							$this->log( sprintf(
+								__( 'Updated %s for "%s" (ID #%d)', 'mu-migration' ),
+								$f,
+								$result->post_title,
+								absint( $result->ID )
+							), $verbose );
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The command line argument `uid_fields` will tell MU-Migration that there are `postmeta` fields containing user ids, and that those fields will need to be included in user id mapping on import.

This basically just extends the existing functionality around WooCommerce customer field to include an arbitrary set of `postmeta` fields. The WooCommerce field is automatically added to the list of user id fields if WooCommerce is active.

Example:
```
wp mu-migration import all mysite.zip --new_url=example.com/mysite --uid_fields='_content_audit_owner,_another_postmeta_userid_field'
```

Manual testing indicates that this works. I'd like to develop unit tests, but haven't gotten to it yet.