### PR TITLE
Test `sed` based on functionality to avoid false negative on OS X.

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -709,9 +709,9 @@ class ImportCommand extends MUMigrationBase {
 	 * @return bool
 	 */
 	private function check_for_sed_presence( $exit_on_error = false ) {
-		$sed = \WP_CLI::launch( 'sed --version', false, false );
+		$sed = \WP_CLI::launch( 'echo "wp_" | sed "s/wp_/wp_5_/g"', false, true );
 
-		if ( 0 !== $sed ) {
+		if ( 'wp_5_' !== trim( $sed->stdout, "\x0A" ) ) {
 			if ( $exit_on_error ) {
 				\WP_CLI::error( __( 'sed not present, please install sed', 'mu-migration' ) );
 			}


### PR DESCRIPTION
Previously, the presence of `sed` was detected by calling it with the `--version` argument, but that is not implemented across all versions of `sed`. For example, OS X ships with FreeBSD `sed`, so some developers testing locally would incorrectly be instructed to install `sed`, even though it already was installed.

`sed` commands are much more consistent between versions than arguments are, so testing the results of a command is more reliable.

Fixes #52