### PR TITLE
Fix wp-cli installation in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,13 @@ before_install:
 
 install:
   - composer require wp-cli/wp-cli:dev-master
+  - composer require wp-cli/core-command:dev-master
+  - composer require wp-cli/config-command:dev-master
+  - composer require wp-cli/db-command:dev-master
+  - composer require wp-cli/entity-command:dev-master
+  - composer require wp-cli/eval-command:dev-master
+  - composer require wp-cli/extension-command:dev-master
+  - composer require wp-cli/media-command:dev-master
   - composer update
   - composer install
   - bash bin/install-package-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ notifications:
     on_success: never
     on_failure: change
 
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - master
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
   - composer require wp-cli/eval-command:dev-master
   - composer require wp-cli/extension-command:dev-master
   - composer require wp-cli/media-command:dev-master
+  - composer require wp-cli/search-replace-command:dev-master
   - composer update
   - composer install
   - bash bin/install-package-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ notifications:
     on_success: never
     on_failure: change
 
-# branches:
-#   only:
-#     - master
+branches:
+  only:
+    - master
 
 cache:
   directories:


### PR DESCRIPTION
The following `wp-cli` packages were added to the composer requirement:
```
core-command
config-command
db-command
entity-command
eval-command
extension-command
media-command
search-replace-command
```