### PR TITLE
MySql foreign keys: add CONSTRAINT and REFERENCES regex to search and replace db prefix list

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -685,6 +685,8 @@ class ImportCommand extends MUMigrationBase {
 				'INSERT INTO',
 				'CREATE TABLE IF NOT EXISTS',
 				'ALTER TABLE',
+				'CONSTRAINT',
+				'REFERENCES',
 			);
 
 			//build sed expressions


### PR DESCRIPTION
The plugin doesn't correctly handle mysql foreign keys.
Adding this two regex fixes the problem (in a database.sql file we can find, for foreign keys, a line like this: ` CONSTRAINT `wp_2251_ab_staff_services_ibfk_1` FOREIGN KEY (`staff_id`) REFERENCES `wp_2251_ab_staff` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,`).