### PR TITLE
Fix db export error.

### DIFF
--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -146,7 +146,7 @@ class ExportCommand extends MUMigrationBase {
 		}
 
 		if ( is_array( $tables ) && ! empty( $tables ) ) {
-            $export = \WP_CLI::runcommand('db export '.$filename, array('return'=>true));
+            $export = \WP_CLI::runcommand('db export '.$filename.' --tables='.implode(',',$tables), array('return'=>true));
             if ( strpos($export, 'Success') === 0 ) {
 				$this->success( __( 'The export is now complete', 'mu-migration' ), $verbose );
 			} else {

--- a/includes/commands/class-mu-migration-export.php
+++ b/includes/commands/class-mu-migration-export.php
@@ -146,16 +146,8 @@ class ExportCommand extends MUMigrationBase {
 		}
 
 		if ( is_array( $tables ) && ! empty( $tables ) ) {
-			$export = \WP_CLI::launch_self(
-				'db export',
-				array( $filename ),
-				array( 'tables' => implode( ',', $tables ) ),
-				false,
-				false,
-				array()
-			);
-
-			if ( 0 === $export ) {
+            $export = \WP_CLI::runcommand('db export '.$filename, array('return'=>true));
+            if ( strpos($export, 'Success') === 0 ) {
 				$this->success( __( 'The export is now complete', 'mu-migration' ), $verbose );
 			} else {
 				\WP_CLI::error( __( 'Something went wrong while trying to export the database', 'mu-migration' ) );


### PR DESCRIPTION
This PR changes how the "db export" is called and might fix the
"Something went wrong while trying to export the database" error that some people including me get.

It replaces the `launch_self()` command with the `runcommand()`. 
Because `runcommand()` returns a different value on success, we also adapt the error handling.

* might fix issue #47 
