### PR TITLE
Support arbitrary site_id

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -636,7 +636,7 @@ class ImportCommand extends MUMigrationBase {
 	 */
 	private function create_new_site( $meta_data ) {
 		$parsed_url = parse_url( esc_url( $meta_data->url ) );
-		$site_id    = 1;
+		$site_id    = get_main_network_id();
 
 		$parsed_url['path'] = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '/';
 


### PR DESCRIPTION
Currently the imported site is hard-coded to have a site_id (network id) of 1. Normally this is fine, but not too long ago I was playing around with a network that had, for unrelated reasons, a site_id of 4, and the hardcoded site_id in MU Migration caught me off guard.

Not a big deal 90% of the time, but it's also really easy to fix and makes MU Migration that little but more robust.