### PR TITLE
create_new_site returning false - replaced insert_blog with wp_insert_site

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -644,7 +644,22 @@ class ImportCommand extends MUMigrationBase {
 			return false;
 		}
 
-		$blog_id = insert_blog( $parsed_url['host'], $parsed_url['path'], $site_id );
+		$now = current_time( 'mysql', true );
+		$new_site_meta = array(
+			'domain'       => $parsed_url['host'],
+			'path'         => $parsed_url['path'],
+			'network_id'   => get_current_network_id(),
+			'registered'   => $now,
+			'last_updated' => $now,
+			'public'       => 1,
+			'archived'     => 0,
+			'mature'       => 0,
+			'spam'         => 0,
+			'deleted'      => 0,
+			'lang_id'      => 0,
+		);
+
+		$blog_id = wp_insert_site( $new_site_meta );
 
 		if ( ! $blog_id ) {
 			return false;

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -648,7 +648,7 @@ class ImportCommand extends MUMigrationBase {
 		$new_site_meta = array(
 			'domain'       => $parsed_url['host'],
 			'path'         => $parsed_url['path'],
-			'network_id'   => get_current_network_id(),
+			'network_id'   => $site_id,
 			'registered'   => $now,
 			'last_updated' => $now,
 			'public'       => 1,


### PR DESCRIPTION
### Description of the Change

Replaced deprecated function `insert_blog()` with `wp_insert_site()`. 

When running `wp mu-migration import all` without passing a value for `--blog_id`, `create_new_site()` returned `false` . This update returns the ID of a newly created site and also creates the site.

Error received:

```PHP Deprecated:  insert_blog is <strong>deprecated</strong> since version 5.1.0! Use wp_insert_site() instead. in .../functions.php on line 4861```

### Benefits

This fix uses the WP replacement for `wp_insert_site()`, `wp_insert_site()` which also returns an int for the ID of the newly created site: https://developer.wordpress.org/reference/functions/wp_insert_site/ . This should simply replace a deprecated function (which is no longer working when testing with WP v5.7.2).

### Possible Drawbacks

The array defined as $new_site_meta var includes predefined values for public, archived, mature, etc. These could present a problem if a migration originates from a multisite. My use test case was for a single site origin.

### Verification Process

Manually running and local unit tests; have not pushed any new tests with this update. 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.