### PR TITLE
Deprecated func fix rename fix

### DIFF
--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -571,7 +571,17 @@ class ImportCommand extends MUMigrationBase {
 
 				if ( ! file_exists( $installed_plugins . '/' . $plugin_folder ) ) {
 					WP_CLI::log( sprintf( __( 'Moving %s to plugins folder' ), $plugin_name ) );
-					rename( $fullPluginPath, $installed_plugins . '/' . $plugin_folder );
+	
+					/**
+					 * PHP has a core bug that prevents rename() from working reliably across filesystems. 
+					 * We'll disable and replace rename() by exec() calls.
+					 * 
+					 * @link https://stackoverflow.com/a/35503748/2209086
+					 * @link https://bugs.php.net/bug.php?id=54097
+					 */
+					// rename( $fullPluginPath, $installed_plugins . '/' . $plugin_folder );
+
+					exec("mv " . escapeshellarg($fullPluginPath) . " " . escapeshellarg($installed_plugins . '/' . $plugin_folder));
 				}
 
 				if ( $check_plugins && in_array( $plugin_name, $blog_plugins, true ) ) {
@@ -619,7 +629,18 @@ class ImportCommand extends MUMigrationBase {
 
 					if ( ! file_exists( $installed_themes . '/' . $theme->getFilename() ) ) {
 						WP_CLI::log( sprintf( __( 'Moving %s to themes folder' ), $theme->getFilename() ) );
-						rename( $fullPluginPath, $installed_themes . '/' . $theme->getFilename() );
+
+						/**
+						 * PHP has a core bug that prevents rename() from working reliably across filesystems. 
+						 * We'll disable and replace rename() by exec() calls.
+						 * 
+						 * @link https://stackoverflow.com/a/35503748/2209086
+						 * @link https://bugs.php.net/bug.php?id=54097
+						 */
+						// rename( $fullPluginPath, $installed_themes . '/' . $theme->getFilename() );
+
+						exec("mv " . escapeshellarg($fullPluginPath) . " " . escapeshellarg($installed_themes . '/' . $theme->getFilename()));
+						
 
 						Helpers\runcommand( 'theme enable', [ $theme->getFilename() ] );
 					}
@@ -644,7 +665,22 @@ class ImportCommand extends MUMigrationBase {
 			return false;
 		}
 
-		$blog_id = insert_blog( $parsed_url['host'], $parsed_url['path'], $site_id );
+		$now = current_time( 'mysql', true );
+		$new_site_meta = array(
+			'domain'       => $parsed_url['host'],
+			'path'         => $parsed_url['path'],
+			'network_id'   => get_current_network_id(),
+			'registered'   => $now,
+			'last_updated' => $now,
+			'public'       => 1,
+			'archived'     => 0,
+			'mature'       => 0,
+			'spam'         => 0,
+			'deleted'      => 0,
+			'lang_id'      => 0,
+		);
+
+		$blog_id = wp_insert_site( $new_site_meta );
 
 		if ( ! $blog_id ) {
 			return false;

--- a/includes/commands/class-mu-migration-import.php
+++ b/includes/commands/class-mu-migration-import.php
@@ -669,7 +669,7 @@ class ImportCommand extends MUMigrationBase {
 		$new_site_meta = array(
 			'domain'       => $parsed_url['host'],
 			'path'         => $parsed_url['path'],
-			'network_id'   => get_current_network_id(),
+			'network_id'   => $site_id,
 			'registered'   => $now,
 			'last_updated' => $now,
 			'public'       => 1,


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
- Closes https://github.com/10up/MU-Migration/pull/95

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Run a single site to multisite import. No PHP deprecated warnings should output to the console. No PHP warnings when moving plugins and themes file assets.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Deprecated WordPress function warning, `insert_blog()` with `wp_insert_site()`.
> Fixed - PHP warning when calling `replace()` - caused by PHP core bug https://bugs.php.net/bug.php?id=54097


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @elvismdev


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
