### PR TITLE
Update Support Level from `Stable` to `Archived`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 > This WP-CLI plugin makes the process of moving sites from single WordPress sites to a Multisite instance (or vice-versa) much easier.  It exports everything into a zip package which can be used to automatically import it within the desired Multisite installation.
 
-[![Build Status](https://travis-ci.org/10up/MU-Migration.svg?branch=master)](https://travis-ci.org/10up/MU-Migration) [![Support Level](https://img.shields.io/badge/support-stable-blue.svg)](#support-level) [![MIT License](https://img.shields.io/github/license/10up/MU-Migration.svg)](https://github.com/10up/MU-Migration/blob/master/LICENSE.md)
+[![Build Status](https://travis-ci.org/10up/MU-Migration.svg?branch=master)](https://travis-ci.org/10up/MU-Migration) [![Support Level](https://img.shields.io/badge/support-archived-red.svg)](#support-level) [![MIT License](https://img.shields.io/github/license/10up/MU-Migration.svg)](https://github.com/10up/MU-Migration/blob/master/LICENSE.md)
+
+> [!CAUTION]
+> As of 2 March 2026, this project is archived and no longer being actively maintained.
 
 ## Install
 
@@ -114,7 +117,7 @@ Depending of the codebase of the site you're migrating you may need to push some
 
 ## Support Level
 
-**Stable:** 10up is not planning to develop any new features for this, but will still respond to bug reports and security concerns. We welcome PRs, but any that include new features should be small and easy to integrate and should not include breaking changes. We otherwise intend to keep this tested up to the most recent version of WordPress.
+**Archived:** This project is no longer maintained by 10up. We are no longer responding to Issues or Pull Requests unless they relate to security concerns. We encourage interested developers to fork this project and make it their own!
 
 ## Credits
 

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,6 @@
   },
     "require-dev": {
         "behat/behat": "~2.5"
-    }
+    },
+  "abandoned": true
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This pull request updates the project status to indicate that it is no longer maintained and has been archived. The most important changes are:

**Documentation updates:**

* Updated the support level in `README.md` from "Stable" to "Archived," clarifying that the project is no longer maintained and that only security-related issues will be addressed.
* Added a caution notice at the top of `README.md` to inform users that the project has been archived as of 2 March 2026 and is not actively maintained.

**Package metadata:**

* Marked the package as abandoned in `composer.json` by adding the `"abandoned": true` property.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Updated Support Level from `Stable` to `Archived`.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
